### PR TITLE
fix(android): Updated version code to better reflect builds.

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -90,7 +90,7 @@ android {
         applicationId "com.versioningrn"
         minSdkVersion 16
         targetSdkVersion 22
-        versionCode versionMajor * 10000 + versionMinor * 100 + versionPatch
+        versionCode versionMajor * 10000 + versionMinor * 1000 + versionPatch * 100
         versionName "${versionMajor}.${versionMinor}.${versionPatch}"
         ndk {
             abiFilters "armeabi-v7a", "x86"


### PR DESCRIPTION
I ran into an issue where I had over 100 version of a patch.  After bumping the minor version Google was complaining about my app code being less than the previous.  I realized that this helped:

major = 10000
minor = 1000
patch = 100

where version `2.1.3` would be version code `21300` rather than `20103`

The issue remains if I go over 999 patch releases however not likely to happen.

Thank you again for your Medium post.  It's been working great for months until this little issue.